### PR TITLE
Check for credentials stored in the AWS console are non empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     - [`/terraform/examples`](#terraformexamples)
     - [`/terraform/modules`](#terraformmodules)
 - [Guide](#guide)
-  - [Pre-requisites](#pre-requisites)
+  - [Prerequisites](#prerequisites)
   - [1. Deploy CI Pipeline.](#1-deploy-ci-pipeline)
   - [2. Review and tune the test code](#2-review-and-tune-the-test-code)
   - [3. Push the code inside your new CodeCommit repository.](#3-push-the-code-inside-your-new-codecommit-repository)
@@ -109,9 +109,9 @@ CodeBuild workflow:
 
 # Guide
 
-## Pre-requisites
+## Prerequisites
 
-The following pre-requisites are necessary in order to run the example.
+The following prerequisites are necessary in order to run the example.
 
 - [Terraform version >= 12](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 - [aws cli v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@
     - [`/terraform/examples`](#terraformexamples)
     - [`/terraform/modules`](#terraformmodules)
 - [Guide](#guide)
+  - [Pre-requisites](#pre-requisites)
   - [1. Deploy CI Pipeline.](#1-deploy-ci-pipeline)
   - [2. Review and tune the test code](#2-review-and-tune-the-test-code)
   - [3. Push the code inside your new CodeCommit repository.](#3-push-the-code-inside-your-new-codecommit-repository)
   - [4. Clean Up](#4-clean-up)
   - [Troubleshooting](#troubleshooting)
-    - [error deleting S3 Bucket (BucketNotEmpty)](#error-deleting-s3-bucket-bucketnotempty)
+    - [Error deleting S3 Bucket (BucketNotEmpty)](#error-deleting-s3-bucket-bucketnotempty)
+  - [Security](#security)
+  - [License](#license)
 
 # Introduction
 
@@ -105,6 +108,16 @@ CodeBuild workflow:
 2. For each run the test reports can be accessed via AWS CodeBuild Console under `Reports` tab.
 
 # Guide
+
+## Pre-requisites
+
+The following pre-requisites are necessary in order to run the example.
+
+- [Terraform version >= 12](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+- [aws cli v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+- [python >= 3.8](https://www.python.org/downloads/)
+- [go >= 1.15.2](https://golang.org/doc/install)
+- [terratest](https://terratest.gruntwork.io/)
 
 ## 1. Deploy CI Pipeline.
 

--- a/terraform/examples/cicd_account/run_terraform.sh
+++ b/terraform/examples/cicd_account/run_terraform.sh
@@ -2,7 +2,7 @@
 
 DELETE_ALL=${1}
 
-if ( [[ -z ${AWS_ACCESS_KEY_ID} ]] || [[ -z ${AWS_SECRET_ACCESS_KEY} ]] ) && [[ -z ${AWS_PROFILE} ]]; then
+if ([[ -z ${AWS_CONTAINER_AUTHORIZATION_TOKEN} ]] && (( [[ -z ${AWS_ACCESS_KEY_ID} ]] || [[ -z ${AWS_SECRET_ACCESS_KEY} ]] ) && [[ -z ${AWS_PROFILE} ]])); then
     echo "[ERROR] Missing AWS credentials variables"
     exit 1
 fi


### PR DESCRIPTION
*Issue #, if available:*
No issue number

*Description of changes:*
On the "run_terraform.sh" file we are not checking for the credentials that work in the AWS console. I added that check using the same kind of logic used (Non empty string)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
