### PR TITLE
Fix locals and region

### DIFF
--- a/terraform/modules/cicd/codebuild_roles_policies.tf
+++ b/terraform/modules/cicd/codebuild_roles_policies.tf
@@ -26,7 +26,7 @@ resource "aws_iam_role_policy" "codebuild_policy" {
       roles                        = var.roles
       codepipeline_artifact_bucket = aws_s3_bucket.codepipeline_bucket.arn
       priv_vpc_id                  = var.priv_vpc_config["vpc_id"]
-      account_id                   = var.account_id
+      account_id                   = local.account_id
       codebuild_kms_key            = aws_kms_key.codebuild-key.arn
   })
 }
@@ -48,7 +48,7 @@ resource "aws_iam_role_policy" "codebuild_deploy_policy" {
 
   policy = templatefile("${path.module}/templates/codebuild-role-policy.json.tpl",
     {
-      account_id                   = var.account_id
-      region                       = var.region
+      account_id                   = local.account_id
+      region                       = local.region
     })
 }

--- a/terraform/modules/cicd/test/cicd_test.go
+++ b/terraform/modules/cicd/test/cicd_test.go
@@ -35,6 +35,10 @@ func TestBitBucketIntegration(t *testing.T) {
 			"account_type":                    "Terratest",
 			"branches":                        []string{"dev"},
 		},
+
+		EnvVars: map[string]string{
+			"AWS_REGION": awsRegion,
+		},
 	}
 
 	// Clean up resources with "terraform destroy" at the end of the test.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Fixing references to `local.region`/`local.account_id`, which were already set but not being used in policies
* settings env var on Terratest so that local executions also work even without an explicit region configured

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
